### PR TITLE
Add compile-time checks to watch for incorrect usage.

### DIFF
--- a/source/utf8/checked.h
+++ b/source/utf8/checked.h
@@ -72,6 +72,8 @@ namespace utf8
     template <typename octet_iterator>
     octet_iterator append(uint32_t cp, octet_iterator result)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         if (!utf8::internal::is_code_point_valid(cp))
             throw invalid_code_point(cp);
 
@@ -98,6 +100,8 @@ namespace utf8
     template <typename octet_iterator, typename output_iterator>
     output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out, uint32_t replacement)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         while (start != end) {
             octet_iterator sequence_start = start;
             internal::utf_error err_code = utf8::internal::validate_next(start, end);
@@ -129,6 +133,8 @@ namespace utf8
     template <typename octet_iterator, typename output_iterator>
     inline output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         static const uint32_t replacement_marker = utf8::internal::mask16(0xfffd);
         return utf8::replace_invalid(start, end, out, replacement_marker);
     }
@@ -136,6 +142,8 @@ namespace utf8
     template <typename octet_iterator>
     uint32_t next(octet_iterator& it, octet_iterator end)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         uint32_t cp = 0;
         internal::utf_error err_code = utf8::internal::validate_next(it, end, cp);
         switch (err_code) {
@@ -156,12 +164,16 @@ namespace utf8
     template <typename octet_iterator>
     uint32_t peek_next(octet_iterator it, octet_iterator end)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         return utf8::next(it, end);
     }
 
     template <typename octet_iterator>
     uint32_t prior(octet_iterator& it, octet_iterator start)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         // can't do much if it == start
         if (it == start)
             throw not_enough_room();
@@ -178,6 +190,8 @@ namespace utf8
     template <typename octet_iterator>
     uint32_t previous(octet_iterator& it, octet_iterator pass_start)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         octet_iterator end = it;
         while (utf8::internal::is_trail(*(--it)))
             if (it == pass_start)
@@ -189,6 +203,8 @@ namespace utf8
     template <typename octet_iterator, typename distance_type>
     void advance (octet_iterator& it, distance_type n, octet_iterator end)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         for (distance_type i = 0; i < n; ++i)
             utf8::next(it, end);
     }
@@ -197,6 +213,8 @@ namespace utf8
     typename std::iterator_traits<octet_iterator>::difference_type
     distance (octet_iterator first, octet_iterator last)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         typename std::iterator_traits<octet_iterator>::difference_type dist;
         for (dist = 0; first < last; ++dist)
             utf8::next(first, last);
@@ -206,6 +224,8 @@ namespace utf8
     template <typename u16bit_iterator, typename octet_iterator>
     octet_iterator utf16to8 (u16bit_iterator start, u16bit_iterator end, octet_iterator result)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         while (start != end) {
             uint32_t cp = utf8::internal::mask16(*start++);
             // Take care of surrogate pairs first
@@ -233,6 +253,8 @@ namespace utf8
     template <typename u16bit_iterator, typename octet_iterator>
     u16bit_iterator utf8to16 (octet_iterator start, octet_iterator end, u16bit_iterator result)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         while (start < end) {
             uint32_t cp = utf8::next(start, end);
             if (cp > 0xffff) { //make a surrogate pair
@@ -248,6 +270,8 @@ namespace utf8
     template <typename octet_iterator, typename u32bit_iterator>
     octet_iterator utf32to8 (u32bit_iterator start, u32bit_iterator end, octet_iterator result)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         while (start != end)
             result = utf8::append(*(start++), result);
 
@@ -319,6 +343,13 @@ namespace utf8
           return temp;
       }
     }; // class iterator
+
+
+    template <typename octet_iterator>
+    struct is_not_utf8_iterator< iterator<octet_iterator> >
+    {
+        // empty class, no is_true() method so will get compile time error
+    };
 
 } // namespace utf8
 

--- a/source/utf8/core.h
+++ b/source/utf8/core.h
@@ -32,6 +32,19 @@ DEALINGS IN THE SOFTWARE.
 
 namespace utf8
 {
+    // simple static assert technique
+    template <class Iterator>
+    struct is_not_utf8_iterator  // specialised in other files
+    {
+        static void must_be_true() {} // will check if function exists, at compile time
+    };
+
+    template <class Iterator>
+    inline void check_is_not_a_utf8_iterator( Iterator const& )
+    {
+        is_not_utf8_iterator<Iterator>::is_true();
+    }
+
     // The typedefs for 8-bit, 16-bit and 32-bit unsigned integers
     // You may need to change them to match your system.
     // These typedefs have the same names as ones from cstdint, or boost/cstdint
@@ -99,6 +112,8 @@ namespace internal
     inline typename std::iterator_traits<octet_iterator>::difference_type
     sequence_length(octet_iterator lead_it)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         uint8_t lead = utf8::internal::mask8(*lead_it);
         if (lead < 0x80)
             return 1;
@@ -137,6 +152,8 @@ namespace internal
     template <typename octet_iterator>
     utf_error increase_safely(octet_iterator& it, octet_iterator end)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         if (++it == end)
             return NOT_ENOUGH_ROOM;
 
@@ -152,6 +169,8 @@ namespace internal
     template <typename octet_iterator>
     utf_error get_sequence_1(octet_iterator& it, octet_iterator end, uint32_t& code_point)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         if (it == end)
             return NOT_ENOUGH_ROOM;
 
@@ -163,6 +182,8 @@ namespace internal
     template <typename octet_iterator>
     utf_error get_sequence_2(octet_iterator& it, octet_iterator end, uint32_t& code_point)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         if (it == end) 
             return NOT_ENOUGH_ROOM;
         
@@ -178,6 +199,8 @@ namespace internal
     template <typename octet_iterator>
     utf_error get_sequence_3(octet_iterator& it, octet_iterator end, uint32_t& code_point)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         if (it == end)
             return NOT_ENOUGH_ROOM;
             
@@ -197,6 +220,8 @@ namespace internal
     template <typename octet_iterator>
     utf_error get_sequence_4(octet_iterator& it, octet_iterator end, uint32_t& code_point)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         if (it == end)
            return NOT_ENOUGH_ROOM;
 
@@ -222,6 +247,8 @@ namespace internal
     template <typename octet_iterator>
     utf_error validate_next(octet_iterator& it, octet_iterator end, uint32_t& code_point)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         // Save the original value of it so we can go back in case of failure
         // Of course, it does not make much sense with i.e. stream iterators
         octet_iterator original_it = it;
@@ -273,6 +300,8 @@ namespace internal
 
     template <typename octet_iterator>
     inline utf_error validate_next(octet_iterator& it, octet_iterator end) {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         uint32_t ignored;
         return utf8::internal::validate_next(it, end, ignored);
     }
@@ -287,6 +316,8 @@ namespace internal
     template <typename octet_iterator>
     octet_iterator find_invalid(octet_iterator start, octet_iterator end)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         octet_iterator result = start;
         while (result != end) {
             utf8::internal::utf_error err_code = utf8::internal::validate_next(result, end);
@@ -299,12 +330,16 @@ namespace internal
     template <typename octet_iterator>
     inline bool is_valid(octet_iterator start, octet_iterator end)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         return (utf8::find_invalid(start, end) == end);
     }
 
     template <typename octet_iterator>
     inline bool starts_with_bom (octet_iterator it, octet_iterator end)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         return (
             ((it != end) && (utf8::internal::mask8(*it++)) == bom[0]) &&
             ((it != end) && (utf8::internal::mask8(*it++)) == bom[1]) &&
@@ -316,6 +351,8 @@ namespace internal
     template <typename octet_iterator>
     inline bool is_bom (octet_iterator it)
     {
+        is_not_utf8_iterator<octet_iterator>::must_be_true();
+
         return (
             (utf8::internal::mask8(*it++)) == bom[0] &&
             (utf8::internal::mask8(*it++)) == bom[1] &&

--- a/source/utf8/unchecked.h
+++ b/source/utf8/unchecked.h
@@ -37,6 +37,8 @@ namespace utf8
         template <typename octet_iterator>
         octet_iterator append(uint32_t cp, octet_iterator result)
         {
+            is_not_utf8_iterator<octet_iterator>::must_be_true();
+
             if (cp < 0x80)                        // one octet
                 *(result++) = static_cast<uint8_t>(cp);  
             else if (cp < 0x800) {                // two octets
@@ -60,6 +62,8 @@ namespace utf8
         template <typename octet_iterator>
         uint32_t next(octet_iterator& it)
         {
+            is_not_utf8_iterator<octet_iterator>::must_be_true();
+
             uint32_t cp = utf8::internal::mask8(*it);
             typename std::iterator_traits<octet_iterator>::difference_type length = utf8::internal::sequence_length(it);
             switch (length) {
@@ -91,12 +95,16 @@ namespace utf8
         template <typename octet_iterator>
         uint32_t peek_next(octet_iterator it)
         {
+            is_not_utf8_iterator<octet_iterator>::must_be_true();
+
             return utf8::unchecked::next(it);    
         }
 
         template <typename octet_iterator>
         uint32_t prior(octet_iterator& it)
         {
+            is_not_utf8_iterator<octet_iterator>::must_be_true();
+
             while (utf8::internal::is_trail(*(--it))) ;
             octet_iterator temp = it;
             return utf8::unchecked::next(temp);
@@ -106,12 +114,16 @@ namespace utf8
         template <typename octet_iterator>
         inline uint32_t previous(octet_iterator& it)
         {
+            is_not_utf8_iterator<octet_iterator>::must_be_true();
+
             return utf8::unchecked::prior(it);
         }
 
         template <typename octet_iterator, typename distance_type>
         void advance (octet_iterator& it, distance_type n)
         {
+            is_not_utf8_iterator<octet_iterator>::must_be_true();
+
             for (distance_type i = 0; i < n; ++i)
                 utf8::unchecked::next(it);
         }
@@ -120,6 +132,8 @@ namespace utf8
         typename std::iterator_traits<octet_iterator>::difference_type
         distance (octet_iterator first, octet_iterator last)
         {
+            is_not_utf8_iterator<octet_iterator>::must_be_true();
+
             typename std::iterator_traits<octet_iterator>::difference_type dist;
             for (dist = 0; first < last; ++dist) 
                 utf8::unchecked::next(first);
@@ -129,6 +143,8 @@ namespace utf8
         template <typename u16bit_iterator, typename octet_iterator>
         octet_iterator utf16to8 (u16bit_iterator start, u16bit_iterator end, octet_iterator result)
         {       
+            is_not_utf8_iterator<octet_iterator>::must_be_true();
+
             while (start != end) {
                 uint32_t cp = utf8::internal::mask16(*start++);
             // Take care of surrogate pairs first
@@ -144,6 +160,8 @@ namespace utf8
         template <typename u16bit_iterator, typename octet_iterator>
         u16bit_iterator utf8to16 (octet_iterator start, octet_iterator end, u16bit_iterator result)
         {
+            is_not_utf8_iterator<octet_iterator>::must_be_true();
+
             while (start < end) {
                 uint32_t cp = utf8::unchecked::next(start);
                 if (cp > 0xffff) { //make a surrogate pair
@@ -159,6 +177,8 @@ namespace utf8
         template <typename octet_iterator, typename u32bit_iterator>
         octet_iterator utf32to8 (u32bit_iterator start, u32bit_iterator end, octet_iterator result)
         {
+            is_not_utf8_iterator<octet_iterator>::must_be_true();
+
             while (start != end)
                 result = utf8::unchecked::append(*(start++), result);
 
@@ -168,6 +188,8 @@ namespace utf8
         template <typename octet_iterator, typename u32bit_iterator>
         u32bit_iterator utf8to32 (octet_iterator start, octet_iterator end, u32bit_iterator result)
         {
+            is_not_utf8_iterator<octet_iterator>::must_be_true();
+
             while (start < end)
                 (*result++) = utf8::unchecked::next(start);
 
@@ -221,6 +243,14 @@ namespace utf8
           }; // class iterator
 
     } // namespace utf8::unchecked
+
+
+    template <typename octet_iterator>
+    struct is_not_utf8_iterator< unchecked::iterator<octet_iterator> >
+    {
+        // empty class, no is_true() method so will get compile time error
+    };
+
 } // namespace utf8 
 
 


### PR DESCRIPTION
Check that UTF-32/16 functions aren't given what looks like utf-8 input.