### PR TITLE
Silence -Wshadow warnings

### DIFF
--- a/source/utf8/checked.h
+++ b/source/utf8/checked.h
@@ -41,7 +41,7 @@ namespace utf8
     class invalid_code_point : public exception {
         uint32_t cp;
     public:
-        invalid_code_point(uint32_t cp) : cp(cp) {}
+        invalid_code_point(uint32_t _cp) : cp(_cp) {}
         virtual const char* what() const throw() { return "Invalid code point"; }
         uint32_t code_point() const {return cp;}
     };
@@ -272,9 +272,9 @@ namespace utf8
       public:
       iterator () {}
       explicit iterator (const octet_iterator& octet_it,
-                         const octet_iterator& range_start,
-                         const octet_iterator& range_end) :
-               it(octet_it), range_start(range_start), range_end(range_end)
+                         const octet_iterator& _range_start,
+                         const octet_iterator& _range_end) :
+               it(octet_it), range_start(_range_start), range_end(_range_end)
       {
           if (it < range_start || it > range_end)
               throw std::out_of_range("Invalid utf-8 iterator position");


### PR DESCRIPTION
In a project where I use utfcpp, I have all the compiler warnings that I can turned on. utfcpp trips the -Wshadow warning of gcc/clang in a couple of places. This is a little annoying, so this PR silences the warnings.
