### PR TITLE
Check for end iterator before using iterator

### DIFF
--- a/source/utf8/core.h
+++ b/source/utf8/core.h
@@ -222,6 +222,9 @@ namespace internal
     template <typename octet_iterator>
     utf_error validate_next(octet_iterator& it, octet_iterator end, uint32_t& code_point)
     {
+	if (it == end)
+            return NOT_ENOUGH_ROOM;
+
         // Save the original value of it so we can go back in case of failure
         // Of course, it does not make much sense with i.e. stream iterators
         octet_iterator original_it = it;


### PR DESCRIPTION
If it == end, then sequence_length(it) will be called which will attempt to dereference the it iterator. This is normally harmless, because the get_sequence_x() functions each check to see whether it == end. However, some runtime libraries (MSVC CRT debug build in particular) check the validity of every iterator dereference, and a runtime check will be triggered inside sequence_length() if it is at the end.