### PR TITLE
Install headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project (utf8cpp)
 include_directories ("${PROJECT_SOURCE_DIR}/source")
 
 include(GNUInstallDirs)
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/source/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/utfcpp/)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/source/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/utfcpp)
 
 add_executable(smoke ${PROJECT_SOURCE_DIR}/test_drivers/smoke_test/test.cpp)
 add_executable(negative ${PROJECT_SOURCE_DIR}/test_drivers/negative/negative.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required (VERSION 2.8.0)
 project (utf8cpp)
 include_directories ("${PROJECT_SOURCE_DIR}/source")
 
-include(GNUInstallDirs)
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/source/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/utfcpp)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/source/ DESTINATION include/utfcpp)
 
 add_executable(smoke ${PROJECT_SOURCE_DIR}/test_drivers/smoke_test/test.cpp)
 add_executable(negative ${PROJECT_SOURCE_DIR}/test_drivers/negative/negative.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required (VERSION 2.8.0)
 project (utf8cpp)
 include_directories ("${PROJECT_SOURCE_DIR}/source")
 
+include(GNUInstallDirs)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/source/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/utfcpp/)
+
 add_executable(smoke ${PROJECT_SOURCE_DIR}/test_drivers/smoke_test/test.cpp)
 add_executable(negative ${PROJECT_SOURCE_DIR}/test_drivers/negative/negative.cpp)
 add_executable(utf8reader ${PROJECT_SOURCE_DIR}/test_drivers/utf8reader/utf8reader.cpp)


### PR DESCRIPTION
Can be used in cmake `ExternalProject_Add()`:

```bash
set(EXTERNAL_PROJECTS_PREFIX ${CMAKE_BINARY_DIR}/external-projects)
set(EXTERNAL_PROJECTS_INSTALL_PREFIX ${EXTERNAL_PROJECTS_PREFIX}/installed)

include(GNUInstallDirs)

# MUST be called before any add_executable() # https://stackoverflow.com/a/40554704/8766845
link_directories(${EXTERNAL_PROJECTS_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
include_directories($<BUILD_INTERFACE:${EXTERNAL_PROJECTS_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>)

include(ExternalProject)

ExternalProject_Add(externalUTFCPP
    PREFIX "${EXTERNAL_PROJECTS_PREFIX}"
    GIT_REPOSITORY "https://github.com/arteniioleg/utfcpp.git"
    GIT_TAG "master"
    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_PROJECTS_INSTALL_PREFIX}
    )

add_executable(${PROJECT_NAME} src/main.cpp)
add_dependencies(${PROJECT_NAME} externalUTFCPP)
```

In source code:

```cpp
#include <utfcpp/utf8.h>
```