### PR TITLE
Iterators now respect std::iterator deprecation and are now correct...

### DIFF
--- a/source/utf8/checked.h
+++ b/source/utf8/checked.h
@@ -265,11 +265,18 @@ namespace utf8
 
     // The iterator class
     template <typename octet_iterator>
-    class iterator : public std::iterator <std::bidirectional_iterator_tag, uint32_t> {
+    class iterator {
       octet_iterator it;
       octet_iterator range_start;
       octet_iterator range_end;
       public:
+
+      using iterator_category = std::bidirectional_iterator_tag;
+      using value_type = uint32_t;
+      using difference_type = ptrdiff_t;
+      using pointer = uint32_t;
+      using reference = uint32_t;
+
       iterator () {}
       explicit iterator (const octet_iterator& octet_it,
                          const octet_iterator& rangestart,

--- a/source/utf8/unchecked.h
+++ b/source/utf8/unchecked.h
@@ -176,9 +176,16 @@ namespace utf8
 
         // The iterator class
         template <typename octet_iterator>
-          class iterator : public std::iterator <std::bidirectional_iterator_tag, uint32_t> { 
+          class iterator { 
             octet_iterator it;
             public:
+
+            using iterator_category = std::bidirectional_iterator_tag;
+            using value_type = uint32_t;
+            using difference_type = ptrdiff_t;
+            using pointer = uint32_t;
+            using reference = uint32_t;
+
             iterator () {}
             explicit iterator (const octet_iterator& octet_it): it(octet_it) {}
             // the default "big three" are OK


### PR DESCRIPTION
...in terms of iterator_traits (pointer and reference are not actually uint32_t* and uint32_t& but regular uint32_t (this enables reversed_iterator among other things))