### PR TITLE
cmake: fixed undefined ${CMAKE_INSTALL_LIBDIR}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(utf8::cpp ALIAS utf8cpp)
 if(WIN32 AND NOT CYGWIN)
     set(DEF_INSTALL_CMAKE_DIR CMake)
 else()
+    include(GNUInstallDirs) # define CMAKE_INSTALL_*
     set(DEF_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/utf8cpp)
 endif()
 


### PR DESCRIPTION
I get error

```
CMake Error at cmake_install.cmake:65 (file):
  file cannot create directory: /cmake/utf8cpp.  Maybe need administrative
  privileges.
```

Steps to reproduce

1. Add in your `CMakeLists.txt`

```
ExternalProject_Add(external_utf_cpp
    PREFIX "${CMAKE_BINARY_DIR}/external-projects"
    URL "https://github.com/nemtrif/utfcpp/archive/e6bde7819c60c453b720b5de8c7c5ee9ffd9805a.zip"
    CMAKE_ARGS
        -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external-projects/installed
        -DUTF8_TESTS=OFF
        -DUTF8_SAMPLES=OFF
    )
```

2. Build target `external_utf_cpp`