### PR TITLE
replace_invalid: Replace final incomplete sequence

### DIFF
--- a/source/utf8/checked.h
+++ b/source/utf8/checked.h
@@ -107,7 +107,9 @@ namespace utf8
                         *out++ = *it;
                     break;
                 case internal::NOT_ENOUGH_ROOM:
-                    throw not_enough_room();
+                    out = utf8::append (replacement, out);
+                    start = end;
+                    break;
                 case internal::INVALID_LEAD:
                     out = utf8::append (replacement, out);
                     ++start;


### PR DESCRIPTION
In replace_invalid, if `NOT_ENOUGH_ROOM` is returned by `validate_next` then it simply means there is an incomplete sequence at the end of the input.

Replace it instead of erroring out.

Example: https://github.com/sass/libsass/files/2064758/test_m001.txt