### PR TITLE
Always use GNU install layout except MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(utf8cpp INTERFACE
 add_library(utf8::cpp ALIAS utf8cpp)
 
 if(UTF8_INSTALL)
-    if(WIN32 AND NOT CYGWIN)
+    if(MSVC)
         set(DEF_INSTALL_CMAKE_DIR CMake)
     else()
         include(GNUInstallDirs) # define CMAKE_INSTALL_*


### PR DESCRIPTION
Current for win32 targets the cmake config file is installed in INSTALL_PREFIX/CMake except for cygwin. 

But we want this also for MinGW, so I I'm thinking we want only this behavior for visual studio. 

What do you think ?