### PR TITLE
Enable tests, docu, install only when building as root project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,15 @@
 cmake_minimum_required (VERSION 3.0.2)
 project (utf8cpp VERSION 3.1 LANGUAGES CXX)
 
-option(UTF8_TESTS "Enable tests for UTF8-CPP" On)
-option(UTF8_INSTALL "Enable installation for UTF8-CPP" On)
-option(UTF8_SAMPLES "Enable building samples for UTF8-CPP" On)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(IS_ROOT_PROJECT ON)
+else()
+    set(IS_ROOT_PROJECT OFF)
+endif()
+
+option(UTF8_TESTS "Enable tests for UTF8-CPP" ${IS_ROOT_PROJECT})
+option(UTF8_INSTALL "Enable installation for UTF8-CPP" ${IS_ROOT_PROJECT})
+option(UTF8_SAMPLES "Enable building samples for UTF8-CPP" ${IS_ROOT_PROJECT})
 
 add_library(utf8cpp INTERFACE)
 target_include_directories(utf8cpp INTERFACE


### PR DESCRIPTION
This allows use via `add_subdirectory`