### PR TITLE
Implement istream_iterator support for checked iterators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,12 @@
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 3.1.3)
 project (utf8cpp VERSION 3.1 LANGUAGES CXX)
 
 option(UTF8_TESTS "Enable tests for UTF8-CPP" On)
 option(UTF8_INSTALL "Enable installation for UTF8-CPP" On)
 option(UTF8_SAMPLES "Enable building samples for UTF8-CPP" On)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(utf8cpp INTERFACE)
 target_include_directories(utf8cpp INTERFACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ endif()
 
 if(UTF8_TESTS)
     enable_testing()
+    set(INSTALL_GTEST OFF CACHE INTERNAL "")
+    set(gtest_force_shared_crt ON CACHE INTERNAL "Need to use shared DLL for MSVC to avoid conflicts when linking")
     add_subdirectory(extern/gtest)
     add_subdirectory(tests)
 endif()

--- a/source/utf8/checked.h
+++ b/source/utf8/checked.h
@@ -158,12 +158,14 @@ namespace utf8
     template <typename octet_iterator>
     uint32_t peek_next(octet_iterator it, octet_iterator end)
     {
+        static_assert(internal::is_iterator_category<octet_iterator, std::bidirectional_iterator_tag>::value, "Using a non-bidirectional iterator eats its input");
         return utf8::next(it, end);
     }
 
     template <typename octet_iterator>
     uint32_t prior(octet_iterator& it, octet_iterator start)
     {
+        static_assert(internal::is_iterator_category<octet_iterator, std::bidirectional_iterator_tag>::value, "Bidirectional iterator is required");
         // can't do much if it == start
         if (it == start)
             throw not_enough_room();
@@ -264,16 +266,13 @@ namespace utf8
     namespace internal
     {
         template<typename iterator>
-        using is_random_access_iterator = std::is_same<typename std::iterator_traits<iterator>::iterator_category, std::random_access_iterator_tag>;
-
-        template<typename iterator>
-        typename std::enable_if<is_random_access_iterator<iterator>::value, bool>::type
+        typename std::enable_if<is_iterator_category<iterator, std::random_access_iterator_tag>::value, bool>::type
             assert_iterator_in_range(const iterator& it, const iterator& rangestart, const iterator& rangeend){
             return it >= rangestart && it <= rangeend;
         }
 
         template<typename iterator>
-        typename std::enable_if<!is_random_access_iterator<iterator>::value, bool>::type
+        typename std::enable_if<!is_iterator_category<iterator, std::random_access_iterator_tag>::value, bool>::type
             assert_iterator_in_range(const iterator&, const iterator&, const iterator&){
             return true; // Cannot check
         }

--- a/source/utf8/core.h
+++ b/source/utf8/core.h
@@ -59,6 +59,10 @@ namespace utf8
 // Helper code - not intended to be directly called by the library users. May be changed at any time
 namespace internal
 {
+    // Trait which is true iff the iterator has at least the given category
+    template<typename iterator, typename category>
+    using is_iterator_category = std::is_convertible<typename std::iterator_traits<iterator>::iterator_category, category>;
+
     // Unicode constants
     // Leading (high) surrogates: 0xd800 - 0xdbff
     // Trailing (low) surrogates: 0xdc00 - 0xdfff

--- a/source/utf8/unchecked.h
+++ b/source/utf8/unchecked.h
@@ -218,6 +218,7 @@ namespace utf8
         // The iterator class
         template <typename octet_iterator>
           class iterator : public std::iterator <std::bidirectional_iterator_tag, uint32_t> { 
+            static_assert(internal::is_iterator_category<octet_iterator, std::bidirectional_iterator_tag>::value, "Bidirectional iterator is required");
             octet_iterator it;
             public:
             iterator () {}

--- a/tests/test_checked_iterator.cpp
+++ b/tests/test_checked_iterator.cpp
@@ -29,3 +29,24 @@ TEST(CheckedIteratrTests, test_decrement)
     EXPECT_EQ (--it, utf8::iterator<const char*>(threechars, threechars, threechars + 9));
     EXPECT_EQ (*it, 0x10346);
 }
+
+TEST(CheckedIteratrTests, test_istream_iterator)
+{
+    std::istringstream is("\xf0\x90\x8d\x86\xe6\x97\xa5\xd1\x88");
+    using iterator = std::istream_iterator<char>;
+    using utf8_iterator = utf8::iterator<iterator>;
+    iterator base_it{is};
+    utf8_iterator it(base_it, base_it, iterator{});
+    utf8_iterator it2 = it;
+    EXPECT_EQ(it2, it);
+    EXPECT_EQ(*it, 0x10346);
+    // Dereferencing it multiple times does not change the value
+    EXPECT_EQ(*it, 0x10346);
+    EXPECT_EQ(*(++it), 0x65e5);
+    EXPECT_EQ((*it++), 0x65e5);
+    EXPECT_EQ(*it, 0x0448);
+    EXPECT_NE(it, it2);
+    utf8_iterator endit(iterator{}, base_it, iterator{});
+    EXPECT_EQ(++it, endit);
+}
+


### PR DESCRIPTION
This is supposed to fix #47:

The current implementation of `iterator` assumes a `bidirectional_iterator` which e.g. an `istream_iterator` is not.

The solution for the checked iterator is to read the next char as soon as the iterator is constructed or incremented, cache it and return it on dereference. Errors are handled the same way: They are returned on dereference.    
This follows the specification of e.g. `istream_iterator` itself.

To provide faster access, smaller memory footprint and bidirectional iterator behavior for base iterators supporting this the implementation is split in 2 and selected via a template class. The interface stays (mostly) the same. Noticeable difference would be in ABI and when trying to forward declare the iterator template.

A Test is included.

To reduce the boilerplate and simplify the template, C++11 features are used which raises the minimum requirements for this library. I suggest to remove all switching code to support pre-C++11 and raise the project version to 4.0 as per semantic versioning. This would be a good point to decide on folders/namespaces, see #54 and #53 

Note that this implementation for an unchecked iterator is not as easy, as an end iterator is required. 