### PR TITLE
Fix C++11 support detection for Visual Studio compilers

### DIFF
--- a/source/utf8/checked.h
+++ b/source/utf8/checked.h
@@ -325,7 +325,7 @@ namespace utf8
 
 } // namespace utf8
 
-#if UTF_CPP_CPLUSPLUS >= 201103L // C++ 11 or later
+#if UTF_CPP_CPLUSPLUS >= 201103L || defined(_MSVC_LANG) // C++ 11 or later
 #include "cpp11.h"
 #endif // C++ 11 or later
 


### PR DESCRIPTION
Simply checking on the value of the `__cplusplus` preprocessor variable when using MSVC 
is [not reliable](https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/) to detect C++11 support. Checking on the definition of the `_MSVC_LANG` one is 
more robust as it was not the case before Visual Studio 2015 which is the first release to 
fully implement C++11 specifications.

Without that fix, the following errors were reported after upgrading to `utfcpp 3.1` when building 
with MSVC on the software I am working on (CI build details [here](https://ci.appveyor.com/project/anlambert/talipot/builds/31425692/job/9b4w7gc5jqw0lln9)):
```
c:\projects\talipot\thirdparty\utf8-cpp\utf8/checked.h(79): error C2676: binary '++': 'octet_iterator' does not define this operator or a conversion to a type acceptable to the predefined operator [C:\projects\talipot\build\library\talipot-core\src\talipot-core-1_0.vcxproj]
c:\projects\talipot\thirdparty\utf8-cpp\utf8/checked.h(81): error C2676: binary '++': 'octet_iterator' does not define this operator or a conversion to a type acceptable to the predefined operator [C:\projects\talipot\build\library\talipot-core\src\talipot-core-1_0.vcxproj]
c:\projects\talipot\thirdparty\utf8-cpp\utf8/checked.h(82): error C2676: binary '++': 'octet_iterator' does not define this operator or a conversion to a type acceptable to the predefined operator [C:\projects\talipot\build\library\talipot-core\src\talipot-core-1_0.vcxproj]
c:\projects\talipot\thirdparty\utf8-cpp\utf8/checked.h(85): error C2676: binary '++': 'octet_iterator' does not define this operator or a conversion to a type acceptable to the predefined operator [C:\projects\talipot\build\library\talipot-core\src\talipot-core-1_0.vcxproj]
c:\projects\talipot\thirdparty\utf8-cpp\utf8/checked.h(86): error C2676: binary '++': 'octet_iterator' does not define this operator or a conversion to a type acceptable to the predefined operator [C:\projects\talipot\build\library\talipot-core\src\talipot-core-1_0.vcxproj]
c:\projects\talipot\thirdparty\utf8-cpp\utf8/checked.h(87): error C2676: binary '++': 'octet_iterator' does not define this operator or a conversion to a type acceptable to the predefined operator [C:\projects\talipot\build\library\talipot-core\src\talipot-core-1_0.vcxproj]
c:\projects\talipot\thirdparty\utf8-cpp\utf8/checked.h(90): error C2676: binary '++': 'octet_iterator' does not define this operator or a conversion to a type acceptable to the predefined operator [C:\projects\talipot\build\library\talipot-core\src\talipot-core-1_0.vcxproj]
c:\projects\talipot\thirdparty\utf8-cpp\utf8/checked.h(91): error C2676: binary '++': 'octet_iterator' does not define this operator or a conversion to a type acceptable to the predefined operator [C:\projects\talipot\build\library\talipot-core\src\talipot-core-1_0.vcxproj]
c:\projects\talipot\thirdparty\utf8-cpp\utf8/checked.h(92): error C2676: binary '++': 'octet_iterator' does not define this operator or a conversion to a type acceptable to the predefined operator [C:\projects\talipot\build\library\talipot-core\src\talipot-core-1_0.vcxproj]
c:\projects\talipot\thirdparty\utf8-cpp\utf8/checked.h(93): error C2676: binary '++': 'octet_iterator' does not define this operator or a conversion to a type acceptable to the predefined operator [C:\projects\talipot\build\library\talipot-core\src\talipot-core-1_0.vcxproj]
```