### PR TITLE
Update CMakeLists.txt, change libdir to datadir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(UTF8_INSTALL)
         set(DEF_INSTALL_CMAKE_DIR CMake)
     else()
         include(GNUInstallDirs) # define CMAKE_INSTALL_*
-        set(DEF_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/utf8cpp)
+        set(DEF_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_DATADIR}/cmake/utf8cpp)
     endif()
 
     install(DIRECTORY source/ DESTINATION include/utf8cpp)


### PR DESCRIPTION
Hello,
While trying to build package for openSUSE, I found that some file is here /usr/lib64/cmake/utf8cpp/utf8cppConfig.cmake
From what I understand, .cmake is an architecture independent file, which I think it is better be placed at /usr/share/cmake/utf8cpp/utf8cppConfig.cmake
I have found that Fedora decided to do as that in this patch I link below. 
What do you think?
https://src.fedoraproject.org/rpms/utf8cpp/blob/master/f/utf8cpp-noarch.patch