### PR TITLE
Bazel build support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,66 @@
+# Master Bazel build file for utfcpp library.
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "utfcpp",
+    includes = ["source"],
+    hdrs = [
+        "source/utf8.h",
+        "source/utf8/checked.h",
+        "source/utf8/unchecked.h",
+        "source/utf8/core.h",
+        "source/utf8/cpp11.h",
+    ],
+)
+
+cc_binary(
+    name = "docsample",
+    srcs = ["samples/docsample.cpp"],
+    deps = [":utfcpp"],
+)
+
+cc_test(
+    name = "test_checked_api",
+    srcs = ["tests/test_checked_api.cpp"],
+    deps = [
+        ":utfcpp",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "test_checked_iterator",
+    srcs = ["tests/test_checked_iterator.cpp"],
+    deps = [
+        ":utfcpp",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "test_unchecked_api",
+    srcs = ["tests/test_unchecked_api.cpp"],
+    deps = [
+        ":utfcpp",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "test_unchecked_iterator",
+    srcs = ["tests/test_unchecked_iterator.cpp"],
+    deps = [
+        ":utfcpp",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "test_cpp11",
+    srcs = ["tests/test_cpp11.cpp"],
+    deps = [
+        ":utfcpp",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,3 +1,11 @@
 # Bazel (https://bazel.build/) workspace.
 
 workspace(name = "com_github_utfcpp")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "com_google_googletest",
+    strip_prefix = "googletest-master",
+    urls = ["https://github.com/google/googletest/archive/master.zip"],
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,3 @@
+# Bazel (https://bazel.build/) workspace.
+
+workspace(name = "com_github_utfcpp")


### PR DESCRIPTION
Support for Bazel (https://bazel.build/) build system. This allows other GitHub repos depend on `utfcpp` remotely. This PR consists of two files:

1. `WORKSPACE.bazel`: Definition of the Bazel workspace.
2. `BUILD.bazel`: Actual build file.

To check these changes using Bazel (assuming that Bazel is installed):

```shell
bazel test -c ...
```
