### PR TITLE
Fix the inclusion of both cpp11 and cpp17 headers on C++17 compilation

### DIFF
--- a/source/utf8/cpp17.h
+++ b/source/utf8/cpp17.h
@@ -29,11 +29,15 @@ DEALINGS IN THE SOFTWARE.
 #define UTF8_FOR_CPP_7e906c01_03a3_4daf_b420_ea7ea952b3c9
 
 #include "checked.h"
-#include "cpp11.h"
 #include <string>
 
 namespace utf8
 {
+
+    inline void append(char32_t cp, std::string& s)
+    {
+        append(uint32_t(cp), std::back_inserter(s));
+    }
 
     inline std::string utf16to8(std::u16string_view s)
     {


### PR DESCRIPTION
When both the string and string_view function interfaces are defined, compilation fails with char types.

```
utf8::utf8to16(std::string{}); // OK
utf8::utf8to16(std::string_view{}); // OK
utf8::utf8to16(""); // Error C2668: ambiguous call to overloaded function
```

Only the string_view interface should be defined on C++17.