### PR TITLE
Add feature to escape non-printable characters

### DIFF
--- a/source/utf8/core.h
+++ b/source/utf8/core.h
@@ -133,19 +133,24 @@ namespace internal
     inline bool is_overlong_sequence(uint32_t cp, octet_difference_type length)
     {
         if (cp < 0x80) {
-            if (length != 1) 
+            if (length != 1)
                 return true;
         }
         else if (cp < 0x800) {
-            if (length != 2) 
+            if (length != 2)
                 return true;
         }
         else if (cp < 0x10000) {
-            if (length != 3) 
+            if (length != 3)
                 return true;
         }
 
         return false;
+    }
+
+    inline bool is_c0c1_control_code(uint32_t cp)
+    {
+        return (cp < 0x1f) || (cp >= 0x80 && cp <= 0x9f);
     }
 
     enum utf_error {UTF8_OK, NOT_ENOUGH_ROOM, INVALID_LEAD, INCOMPLETE_SEQUENCE, OVERLONG_SEQUENCE, INVALID_CODE_POINT};
@@ -163,7 +168,7 @@ namespace internal
         return UTF8_OK;
     }
 
-    #define UTF8_CPP_INCREASE_AND_RETURN_ON_ERROR(IT, END) {utf_error ret = increase_safely(IT, END); if (ret != UTF8_OK) return ret;}    
+    #define UTF8_CPP_INCREASE_AND_RETURN_ON_ERROR(IT, END) {utf_error ret = increase_safely(IT, END); if (ret != UTF8_OK) return ret;}
 
     /// get_sequence_x functions decode utf-8 sequences of the length x
     template <typename octet_iterator>
@@ -180,7 +185,7 @@ namespace internal
     template <typename octet_iterator>
     utf_error get_sequence_2(octet_iterator& it, octet_iterator end, uint32_t& code_point)
     {
-        if (it == end) 
+        if (it == end)
             return NOT_ENOUGH_ROOM;
 
         code_point = utf8::internal::mask8(*it);
@@ -197,7 +202,7 @@ namespace internal
     {
         if (it == end)
             return NOT_ENOUGH_ROOM;
-            
+
         code_point = utf8::internal::mask8(*it);
 
         UTF8_CPP_INCREASE_AND_RETURN_ON_ERROR(it, end)
@@ -282,7 +287,7 @@ namespace internal
                 else
                     err = OVERLONG_SEQUENCE;
             }
-            else 
+            else
                 err = INVALID_CODE_POINT;
         }
 


### PR DESCRIPTION
Thank you for your effort to make a wonderful library, but recently I have found out the library has a shortcoming which is it doesn't escape the non-printable UTF8 characters correctly. 

I try to send JSON data containing UTF-8 characters to the browser,  and the browser treats the non-printable UTF8 characters likes '\u0005' as invalid.  So I thought would escape the non-printable character in the `replace_invalid` function cloud be better?

So I post the MR, and any options are welcome. Thanks again for your patience with my first MR for the repository.