### PR TITLE
Suppress sign-conversion warning on append

### DIFF
--- a/source/utf8/checked.h
+++ b/source/utf8/checked.h
@@ -75,6 +75,9 @@ namespace utf8
         if (!utf8::internal::is_code_point_valid(cp))
             throw invalid_code_point(cp);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+
         if (cp < 0x80)                        // one octet
             *(result++) = static_cast<uint8_t>(cp);
         else if (cp < 0x800) {                // two octets
@@ -93,6 +96,7 @@ namespace utf8
             *(result++) = static_cast<uint8_t>((cp & 0x3f)          | 0x80);
         }
         return result;
+#pragma GCC diagnostic pop
     }
 
     template <typename octet_iterator, typename output_iterator>


### PR DESCRIPTION
Since #92 is not really fixed, we should suppress the compiler warning.
I was hardly figuring out a solution without suppression, but to have the `append` as generic as it is right now, it is kind of unpredictable which type the overload resolution will pick for `*(result++)*. It could be an `operator=(T)` as well a reference to a type `T`.
Nevertheless, if we let the compiler choose and be aware that target of the assignment can handle the byte-value there is no change to be error prone. Anyway, it should be made explicit to let the compiler choose what ever it might find suitable which may imply an implicit sign-conversion.
That's the reason I'd appreciate to accept the PR or to fix it in any other way so the compilers a de-stressed.