### PR TITLE
Guard add_library in exported config

### DIFF
--- a/utf8cppConfig.cmake.in
+++ b/utf8cppConfig.cmake.in
@@ -3,4 +3,6 @@
 include("${CMAKE_CURRENT_LIST_DIR}/utf8cppTargets.cmake")
 check_required_components( "utf8cpp" )
 
-add_library(utf8::cpp ALIAS utf8cpp)
+if(NOT TARGET utf8::cpp)
+    add_library(utf8::cpp ALIAS utf8cpp)
+endif()


### PR DESCRIPTION
Fixes error when the `find_package` is called a second time:

CMake Error at /home/user/vcpkg/scripts/buildsystems/vcpkg.cmake:639 (_add_library):
_add_library cannot create ALIAS target "utf8::cpp" because another target
with the same name already exists.
Call Stack (most recent call first):
build/vcpkg_installed/x64-linux/share/utf8cpp/utf8cppConfig.cmake:30 (add_library)

(From https://github.com/microsoft/vcpkg/issues/33734)