### PR TITLE
Fix CMake build system to use existing include directory (#112)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(GNUInstallDirs)
 
 target_include_directories(utf8cpp INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/source>"
-    $<INSTALL_INTERFACE:include/utf8cpp>
+    $<INSTALL_INTERFACE:include>
 )
 
 include(CMakePackageConfigHelpers)

--- a/utf8cppConfig.cmake.in
+++ b/utf8cppConfig.cmake.in
@@ -2,3 +2,7 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 check_required_components("@PROJECT_NAME@")
+
+if(NOT TARGET utf8::cpp)
+    add_library(utf8::cpp ALIAS utf8cpp::utf8cpp)
+endif()


### PR DESCRIPTION
Also provide an imported target utf8::cpp for backward compatibility.

See also
- #112 for the reason.
- https://github.com/Homebrew/homebrew-core/issues/153289
- https://github.com/taglib/taglib/commit/70b4ce79fb493e45ae8884389ed146cf334a0369
