### PR TITLE
fix: revert to pre-4.x install path {prefix}/utf8cpp (see #112)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.5...3.27)
-project (utf8cpp 
+project (utf8cpp
          VERSION 4.0.1
          LANGUAGES CXX
          DESCRIPTION "C++ portable library for working with utf-8 encoding")
@@ -10,7 +10,7 @@ include(GNUInstallDirs)
 
 target_include_directories(utf8cpp INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/source>"
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/utf8cpp>
 )
 
 include(CMakePackageConfigHelpers)
@@ -44,5 +44,6 @@ install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
               "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
 
-install(FILES ${PROJECT_SOURCE_DIR}/source/utf8.h DESTINATION include)
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/source/utf8 DESTINATION include)
+install(FILES ${PROJECT_SOURCE_DIR}/source/utf8.h DESTINATION include/utf8cpp)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/source/utf8 DESTINATION
+        include/utf8cpp)


### PR DESCRIPTION
This reverts the install path of the headers to the path that was used before the 4.x release series, unbreaking projects that were building against the library without using the CMake config files.