### PR TITLE
Recover CMake ARCH_INDEPENDENT usage from dbb2423248

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,16 @@ target_include_directories(utf8cpp INTERFACE
     $<INSTALL_INTERFACE:include/utf8cpp>
 )
 
+if(${CMAKE_VERSION} VERSION_GREATER "3.14")
+    set(OPTIONAL_ARCH_INDEPENDENT "ARCH_INDEPENDENT")
+endif()
+
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMajorVersion
+    ${OPTIONAL_ARCH_INDEPENDENT}
 )
 
 install(TARGETS ${PROJECT_NAME}


### PR DESCRIPTION
Usage of CMake ARCH_INDEPENDENT was introduced in https://github.com/nemtrif/utfcpp/commit/dbb2423248dd5b97acd4125a29bdfbf6b36cd7b1 before v3.2.4 release, but got lost with v4.0.x release. This commit recovers this functionality in v4.0.x series.