### PR TITLE
fix msvc support for UTF_CPP_CPLUSPLUS

### DIFF
--- a/source/utf8/core.h
+++ b/source/utf8/core.h
@@ -37,7 +37,11 @@ DEALINGS IN THE SOFTWARE.
 // Otherwise, trust the unreliable predefined macro __cplusplus
 
 #if !defined UTF_CPP_CPLUSPLUS
-    #define UTF_CPP_CPLUSPLUS __cplusplus
+    #if defined _MSVC_LANG
+        #define UTF_CPP_CPLUSPLUS _MSVC_LANG
+    #else
+        #define UTF_CPP_CPLUSPLUS __cplusplus
+    #endif
 #endif
 
 #if UTF_CPP_CPLUSPLUS >= 201103L // C++ 11 or later


### PR DESCRIPTION
> // Determine the C++ standard version.
> // If the user defines UTF_CPP_CPLUSPLUS, use that.
> // Otherwise, trust the unreliable predefined macro __cplusplus

Yeah, in msvc, __cplusplus == 199711L, but we can use _MSVC_LANG for the same behavior. I give this patch because msvc is a popular compiler as gcc, clang.