### PR TITLE
Contributed meson.build/meson.options for use as a meson wrap/subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,41 @@
+project('utfcpp', 'cpp',
+  version: '4.0.9',
+  license: 'BSL-1.0',
+  meson_version: '>= 1.9.0',
+  default_options: {
+    'install': false
+  })
+
+opt_install = get_option('install')
+
+headers = files(
+  'source/utf8/checked.h',
+  'source/utf8/core.h',
+  'source/utf8/cpp11.h',
+  'source/utf8/cpp17.h',
+  'source/utf8/cpp20.h',
+  'source/utf8/unchecked.h'
+)
+
+
+inc = include_directories('source')
+
+utfcpp_dep = declare_dependency(include_directories: inc)
+meson.override_dependency('utfcpp', utfcpp_dep)
+
+
+# only generate the pkgconfig file if we are installing
+if opt_install
+  install_headers('source/utf8.h')
+  install_headers(headers, install_dir: get_option('includedir') / 'utf8')
+
+  pkg = import('pkgconfig')
+  pkg.generate(
+    name: meson.project_name(),
+    filebase: meson.project_name(),
+    url: 'https://github.com/nemtrif/utfcpp',
+    description: 'UTF-8 with C++ in a Portable Way',
+    version: meson.project_version(),
+    license: 'BSL-1.0',
+    install_dir: get_option('datadir') / 'pkgconfig')
+endif

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,4 @@
+option('install',
+       type: 'boolean',
+       value: false,
+       description: 'install utfcpp headers and pkg-config file')


### PR DESCRIPTION
This PR contributes Meson build and options files.

I wrote them myself for personal use in one of my projects, however I figured you might appreciate them upstream.

The `meson.build` file also produces a pkg-config file when the project is configured with `-D install=true`. The `install` option is false by default for streamlined usage as a Meson wrap/subproject, allowing it to be used as easily as creating a `subprojects/utfcpp.wrap` like so:
```ini
[wrap-git]
url = https://github.com/nemtrif/utfcpp.git
revision = v4.0.9 # or another valid git tag
depth = 1

[provide]
utfcpp = utfcpp_dep
```

To update the meson.build when a header file is added:
```python
headers = files(
  # ...
  'source/utf8/new-header.h',
)
```
To update the version:
```python
project('utfcpp', 'cpp',
  version: '<new-version>',
```

To update the license if needed:
```python
project('utfcpp', 'cpp',
  # ...
  license: '<new-license>',
  # ...
)

if opt_install
  # ...
  pkg.generate(
    # ...
    license: '<new-license>',
    # ...
  )
endif
```

If you choose to keep the `meson.build` up-to-date is (of course) your call, as is accepting the contribution altogether obviously; Though a project like yours can be an [invaluable](https://dictionary.com/browse/invaluable) addition to others' projects, and I'm certain many would appreciate it.

Also if you have issue with the way these files are included, we could potentially figure out a `<repo>/contrib/meson.build` inclusion if that is more acceptable to you.