### PR TITLE
Make checked next16 throw on invalid UTF-16

### DIFF
--- a/source/utf8/checked.h
+++ b/source/utf8/checked.h
@@ -172,8 +172,18 @@ namespace utf8
     {
         utfchar32_t cp = 0;
         internal::utf_error err_code = utf8::internal::validate_next16(it, end, cp);
-        if (err_code == internal::NOT_ENOUGH_ROOM)
-            throw not_enough_room();
+        switch (err_code) {
+            case internal::UTF8_OK :
+                break;
+            case internal::NOT_ENOUGH_ROOM :
+                throw not_enough_room();
+            case internal::INVALID_LEAD :
+            case internal::INCOMPLETE_SEQUENCE :
+            case internal::OVERLONG_SEQUENCE :
+                throw invalid_utf16(static_cast<utfchar16_t>(*it));
+            case internal::INVALID_CODE_POINT :
+                throw invalid_code_point(cp);
+        }
         return cp;
     }
 

--- a/tests/test_checked_api.h
+++ b/tests/test_checked_api.h
@@ -120,6 +120,22 @@ TEST(CheckedAPITests, test_next16)
     cp = next16(w, w + 2);
     EXPECT_EQ (cp, 0x10346);
     EXPECT_EQ (w, u + 3);
+
+    // Invalid UTF-16 must throw, not silently return U+0000 without advancing.
+    // A trail surrogate where a lead is expected:
+    const utfchar16_t trail_first[2] = {0xdc00, 0x0041};
+    const utfchar16_t* tf = trail_first;
+    EXPECT_THROW(next16(tf, tf + 2), invalid_utf16);
+
+    // A lead surrogate not followed by a trail surrogate:
+    const utfchar16_t unpaired_lead[2] = {0xd800, 0x0041};
+    const utfchar16_t* ul = unpaired_lead;
+    EXPECT_THROW(next16(ul, ul + 2), invalid_utf16);
+
+    // A lead surrogate with no room for its trailing word:
+    const utfchar16_t lead_at_end[1] = {0xd800};
+    const utfchar16_t* le = lead_at_end;
+    EXPECT_THROW(next16(le, le + 1), not_enough_room);
 }
 
 TEST(CheckedAPITests, test_peek_next)


### PR DESCRIPTION
The checked `next16` only handled `NOT_ENOUGH_ROOM`; for `INVALID_LEAD` and `INCOMPLETE_SEQUENCE` it returned the (zero) code point instead of throwing. So a lone or unpaired surrogate decodes to U+0000 **without advancing the iterator**, and a `while (it != end) next16(it, end)` loop spins forever.

The documented contract is that the checked API throws on invalid UTF-16. This handles every error code like the sibling `next()`, throwing `invalid_utf16` for the surrogate cases (matching what `utf16to8` already does). Added negative cases to `test_next16`; the full test suite (apitests + cpp11/17/20) stays green.
