### PR TITLE
Add utf8cpp::utf8cpp target available when consuming directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project (utf8cpp
          DESCRIPTION "C++ portable library for working with utf-8 encoding")
 
 add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
This allows downstream projects to consume the project in the same way regardless of whether they obtained `utf8cpp` via `FetchContent` (or similar) or via `find_package`.